### PR TITLE
Consolidate logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,14 @@ python group_logs.py /path/to/scanlog.txt
 
 The script writes a new file with `_grouped` appended to the original name.
 
+## Log Files
+
+All logs are written to:
+
+```
+~/OneDrive/Documents/CRYPTO/PYTHON/WORK_IN_PROGRESS/cryptoscanner/logs
+```
+
+`scan.py` writes `scanlog.txt` here, while `run_checks.py` creates
+`pylint.log` and `pytest.log` in the same directory.
+

--- a/run_checks.py
+++ b/run_checks.py
@@ -1,35 +1,46 @@
-"""Run pylint and pytest with tqdm progress bars."""
+"""Run pylint and pytest with tqdm progress bars and write logs."""
+import os
 import subprocess
 import sys
 from pathlib import Path
+from contextlib import redirect_stdout
 
 from tqdm import tqdm
 import pytest
+import core
+
+LOG_DIR = core.LOG_DIR
 
 PY_FILES = ["core.py", "scan.py", "test.py", "volume_math.py"]
 
 
 def run_pylint() -> None:
-    """Run pylint on all target files with a progress bar."""
+    """Run pylint on all target files with a progress bar and log output."""
     for path in PY_FILES:
         if not Path(path).is_file():
             raise FileNotFoundError(f"Missing required file: {path}")
 
-    with tqdm(total=len(PY_FILES), desc="pylint") as pbar:
-        for path in PY_FILES:
-            result = subprocess.run([
-                "pylint",
-                path,
-            ], text=True, capture_output=True)
-            sys.stdout.write(result.stdout)
-            sys.stdout.flush()
-            if result.returncode != 0:
-                raise SystemExit(f"pylint failed for {path}")
-            pbar.update(1)
+    os.makedirs(LOG_DIR, exist_ok=True)
+    log_path = os.path.join(LOG_DIR, "pylint.log")
+
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        with tqdm(total=len(PY_FILES), desc="pylint") as pbar:
+            for path in PY_FILES:
+                result = subprocess.run([
+                    "pylint",
+                    path,
+                ], text=True, capture_output=True)
+                sys.stdout.write(result.stdout)
+                log_file.write(result.stdout)
+                sys.stdout.flush()
+                log_file.flush()
+                if result.returncode != 0:
+                    raise SystemExit(f"pylint failed for {path}")
+                pbar.update(1)
 
 
 def run_pytest() -> None:
-    """Run pytest with a tqdm progress bar for tests."""
+    """Run pytest with a tqdm progress bar for tests and log output."""
 
     class TqdmPlugin:  # pylint: disable=too-few-public-methods
         """pytest plugin showing progress with tqdm."""
@@ -48,7 +59,30 @@ def run_pytest() -> None:
             if self.pbar:
                 self.pbar.close()
 
-    errno = pytest.main(["test.py"], plugins=[TqdmPlugin()])
+    os.makedirs(LOG_DIR, exist_ok=True)
+    log_path = os.path.join(LOG_DIR, "pytest.log")
+
+    class Tee:
+        """Simple class to duplicate writes to multiple streams."""
+
+        def __init__(self, *streams) -> None:
+            self.streams = streams
+
+        def isatty(self) -> bool:  # pragma: no cover - passthrough
+            return any(getattr(s, "isatty", lambda: False)() for s in self.streams)
+
+        def write(self, data: str) -> None:
+            for stream in self.streams:
+                stream.write(data)
+
+        def flush(self) -> None:
+            for stream in self.streams:
+                stream.flush()
+
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        tee = Tee(sys.stdout, log_file)
+        with redirect_stdout(tee):
+            errno = pytest.main(["test.py"], plugins=[TqdmPlugin()])
     if errno != 0:
         raise SystemExit(errno)
 


### PR DESCRIPTION
## Summary
- store pylint and pytest output in same log directory as scanlog
- explain log directory in README

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6841d13c4d8083218c3a03c95ada3011