### PR TITLE
Populate funding rate timestamp

### DIFF
--- a/core.py
+++ b/core.py
@@ -179,8 +179,8 @@ def fetch_recent_klines(symbol: str, interval: str = "1", total: int = 5040) -> 
     return all_klines[-total:]
 
 
-def get_funding_rate(symbol: str) -> float | None:
-    """Return the most recent funding rate if fresher than 3 minutes."""
+def get_funding_rate(symbol: str) -> tuple[float | None, int | None]:
+    """Return the most recent funding rate and its timestamp."""
     url = (
         "https://api.bybit.com/v5/market/funding/history"
         f"?symbol={symbol}&category=linear&limit=1"
@@ -190,17 +190,15 @@ def get_funding_rate(symbol: str) -> float | None:
         response.raise_for_status()
         data = response.json()
         item = data.get("result", {}).get("list", [])[0]
-        rate = float(item.get("fundingRate", 0))
-        ts = int(item.get("fundingRateTimestamp", 0))
-        age_ms = int(datetime.now(timezone.utc).timestamp() * 1000) - ts
-        if age_ms > 3 * 60 * 1000:
-            return None
-        return rate
+        return (
+            float(item.get("fundingRate", 0)),
+            int(item.get("fundingRateTimestamp", 0)),
+        )
     except (IndexError, ValueError, KeyError, requests.RequestException):
         logging.getLogger("volume_logger").warning(
             "Failed to fetch funding rate for %s", symbol
         )
-        return None
+        return None, None
 
 def process_symbol(symbol: str, logger: logging.Logger) -> dict:
     """Fetch klines and compute volume changes for 5m, 15m, 30m, 1h, and 4h blocks."""
@@ -208,6 +206,13 @@ def process_symbol(symbol: str, logger: logging.Logger) -> dict:
     if not klines:
         logger.warning("%s skipped: No valid klines returned.", symbol)
         return None
+    rate, ts = get_funding_rate(symbol)
+    if ts:
+        ts_str = datetime.fromtimestamp(ts / 1000, timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+    else:
+        ts_str = ""
     return {
         "Symbol": symbol,
         "5M": round(calculate_volume_change(klines, 5), 4),
@@ -215,5 +220,6 @@ def process_symbol(symbol: str, logger: logging.Logger) -> dict:
         "30M": round(calculate_volume_change(klines, 30), 4),
         "1H": round(calculate_volume_change(klines, 60), 4),
         "4H": round(calculate_volume_change(klines, 240), 4),
-        "Funding Rate": get_funding_rate(symbol),
+        "Funding Rate": rate,
+        "Funding Rate Timestamp": ts_str,
     }


### PR DESCRIPTION
## Summary
- capture timestamp with each funding rate request
- add Funding Rate Timestamp column when scanning
- update tests for new return type

## Testing
- `pip install -r requirements.txt`
- `python run_checks.py`


------
https://chatgpt.com/codex/tasks/task_e_6841d2047ae88321991e2ed969f80016