### PR TITLE
Fetch funding rate via tickers endpoint

### DIFF
--- a/core.py
+++ b/core.py
@@ -174,8 +174,8 @@ def fetch_recent_klines(symbol: str, interval: str = "1", total: int = 5040) -> 
 def get_funding_rate(symbol: str) -> tuple[float, int]:
     """Return latest funding rate and timestamp for a symbol."""
     url = (
-        "https://api.bybit.com/v5/market/funding/history"
-        f"?symbol={symbol}&category=linear&limit=1"
+        "https://api.bybit.com/v5/market/tickers"
+        f"?category=linear&symbol={symbol}"
     )
     fetch_time = int(datetime.now(timezone.utc).timestamp() * 1000)
     try:
@@ -184,7 +184,7 @@ def get_funding_rate(symbol: str) -> tuple[float, int]:
         data = response.json()
         item = data.get("result", {}).get("list", [])[0]
         rate = float(item.get("fundingRate", 0))
-        ts = int(item.get("fundingRateTimestamp", fetch_time))
+        ts = int(data.get("time", fetch_time))
         return rate, ts
     except (IndexError, ValueError, KeyError, requests.RequestException):
         logging.getLogger("volume_logger").warning(

--- a/test.py
+++ b/test.py
@@ -98,13 +98,10 @@ def test_process_symbol_with_mocked_logger():
 
 def test_get_funding_rate_success_timestamp():
     """Ensure timestamp reflects when the rate was fetched."""
-    mock_data = {"result": {"list": [{"fundingRate": "0.0001"}]}}
-    with patch("core.requests.get") as mock_get:
-        mock_get.return_value.status_code = 200
-        mock_get.return_value.json.return_value = mock_data
     ts = int((datetime.now(timezone.utc) - timedelta(minutes=5)).timestamp() * 1000)
     mock_data = {
-        "result": {"list": [{"fundingRate": "0.0001", "fundingRateTimestamp": str(ts)}]}
+        "result": {"list": [{"fundingRate": "0.0001"}]},
+        "time": str(ts)
     }
     with patch("core.requests.get") as mock_get:
         mock_get.return_value.status_code = 200


### PR DESCRIPTION
## Summary
- retrieve funding rate from `/v5/market/tickers`
- adjust unit test for new funding rate source

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6841eb4af3108321b40f54c3ce05ccef