### PR TITLE
Add email alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,18 @@ All logs are written to:
 `scan.py` writes `scanlog.txt` here, while `run_checks.py` creates
 `pylint.log` and `pytest.log` in the same directory.
 
+## Email Alerts
+
+Set the following environment variables to receive an email after each scan:
+
+```
+SMTP_HOST   # SMTP server hostname
+SMTP_PORT   # SMTP server port
+SMTP_USER   # Username for authentication
+SMTP_PASS   # Password for authentication
+EMAIL_TO    # Recipient email address (defaults to alexx1202@gmail.com)
+EMAIL_FROM  # Sender address (defaults to SMTP_USER)
+```
+
+If any of these variables are missing, email alerts will be skipped.
+

--- a/scan.py
+++ b/scan.py
@@ -6,6 +6,8 @@ Handles logging, threading, Excel export, scan loop.
 import os
 import sys
 import logging
+import smtplib
+from email.message import EmailMessage
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pandas as pd
@@ -56,6 +58,34 @@ def clean_existing_excels(logger: logging.Logger | None = None) -> None:
                 os.remove(file)
             except OSError:
                 logger.warning("Failed to delete %s", file)
+
+def send_email_alert(subject: str, body: str, logger: logging.Logger) -> None:
+    """Send an email alert using SMTP credentials from env vars."""
+    host = os.getenv("SMTP_HOST")
+    port = int(os.getenv("SMTP_PORT", "0"))
+    user = os.getenv("SMTP_USER")
+    password = os.getenv("SMTP_PASS")
+    to_addr = os.getenv("EMAIL_TO", "alexx1202@gmail.com")
+    from_addr = os.getenv("EMAIL_FROM", user or "")
+
+    if not all([host, port, user, password, to_addr]):
+        logger.info("Email not configured. Skipping email alert.")
+        return
+
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = to_addr
+    msg.set_content(body)
+
+    try:
+        with smtplib.SMTP(host, port) as smtp:
+            smtp.starttls()
+            smtp.login(user, password)
+            smtp.send_message(msg)
+        logger.info("Email alert sent to %s", to_addr)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warning("Failed to send email alert: %s", exc)
 
 def export_to_excel(df: pd.DataFrame, symbol_order: list, logger: logging.Logger) -> None:
     """Export results to Excel with formatting."""  # pylint: disable=too-many-locals
@@ -163,6 +193,11 @@ def run_scan(logger: logging.Logger) -> None:
 
     export_to_excel(pd.DataFrame(rows), [s for s, _ in all_symbols], logger)
     logger.info("Export complete: Crypto_Volume.xlsx")
+    send_email_alert(
+        "Volume scan complete",
+        "Crypto_Volume.xlsx has been exported.",
+        logger,
+    )
 
 def main() -> None:
     """Main entry point."""

--- a/test.py
+++ b/test.py
@@ -7,6 +7,7 @@ and Excel export behavior. Supports pytest + pylint 10/10 compliance.
 import logging
 from unittest.mock import patch, MagicMock
 from datetime import datetime, timezone, timedelta
+import os
 import core
 import scan
 from volume_math import calculate_volume_change
@@ -193,3 +194,50 @@ def test_calculate_volume_change_cache_usage():
 
     calculate_volume_change(klines, 5)
     assert len(core.SORTED_KLINES_CACHE) == 1
+
+
+def test_send_email_alert_sends_message():
+    """send_email_alert logs in and sends a message when configured."""
+    logger = MagicMock()
+    env = {
+        "SMTP_HOST": "smtp.example.com",
+        "SMTP_PORT": "587",
+        "SMTP_USER": "user",
+        "SMTP_PASS": "pass",
+        "EMAIL_TO": "to@example.com",
+        "EMAIL_FROM": "from@example.com",
+    }
+    with patch.dict(os.environ, env, clear=True), \
+         patch("scan.smtplib.SMTP") as mock_smtp:
+        smtp_instance = mock_smtp.return_value.__enter__.return_value
+        scan.send_email_alert("sub", "body", logger)
+        smtp_instance.starttls.assert_called_once()
+        smtp_instance.login.assert_called_once_with("user", "pass")
+        smtp_instance.send_message.assert_called_once()
+
+
+def test_send_email_alert_defaults_recipient():
+    """EMAIL_TO defaults to alexx1202@gmail.com if not set."""
+    logger = MagicMock()
+    env = {
+        "SMTP_HOST": "smtp.example.com",
+        "SMTP_PORT": "587",
+        "SMTP_USER": "user",
+        "SMTP_PASS": "pass",
+        "EMAIL_FROM": "from@example.com",
+    }
+    with patch.dict(os.environ, env, clear=True), \
+         patch("scan.smtplib.SMTP") as mock_smtp:
+        smtp_instance = mock_smtp.return_value.__enter__.return_value
+        scan.send_email_alert("sub", "body", logger)
+        sent_msg = smtp_instance.send_message.call_args.args[0]
+        assert sent_msg["To"] == "alexx1202@gmail.com"
+
+
+def test_send_email_alert_skips_if_missing_env():
+    """No SMTP connection attempted when config vars are absent."""
+    logger = MagicMock()
+    with patch.dict(os.environ, {}, clear=True), \
+         patch("scan.smtplib.SMTP") as mock_smtp:
+        scan.send_email_alert("sub", "body", logger)
+        mock_smtp.assert_not_called()


### PR DESCRIPTION
## Summary
- default to sending export alert to alexx1202@gmail.com
- document the default recipient in README
- test fallback behavior when EMAIL_TO is unset

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6841d823638c8321bb3d21d5dabc6e4b