### PR TITLE
Set default email recipient

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ SMTP_HOST   # SMTP server hostname
 SMTP_PORT   # SMTP server port
 SMTP_USER   # Username for authentication
 SMTP_PASS   # Password for authentication
-EMAIL_TO    # Recipient email address
+EMAIL_TO    # Recipient email address (defaults to alexx1202@gmail.com)
 EMAIL_FROM  # Sender address (defaults to SMTP_USER)
 ```
 

--- a/scan.py
+++ b/scan.py
@@ -65,7 +65,7 @@ def send_email_alert(subject: str, body: str, logger: logging.Logger) -> None:
     port = int(os.getenv("SMTP_PORT", "0"))
     user = os.getenv("SMTP_USER")
     password = os.getenv("SMTP_PASS")
-    to_addr = os.getenv("EMAIL_TO")
+    to_addr = os.getenv("EMAIL_TO", "alexx1202@gmail.com")
     from_addr = os.getenv("EMAIL_FROM", user or "")
 
     if not all([host, port, user, password, to_addr]):


### PR DESCRIPTION
## Summary
- default `EMAIL_TO` to `alexx1202@gmail.com`
- document default email in README

## Testing
- `pip install -r requirements.txt`
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6841ed75efd88321aa641f7608151095