### PR TITLE
Remove funding timestamp column, highlight rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Bybit Volume Scanner
 
 This project scans Bybit USDT perpetual markets for unusual volume activity.
-The export also records each funding rate's fetch timestamp.
-The resulting spreadsheet now includes a column showing each pair's total 24​hr trading volume.
+The resulting spreadsheet includes each pair's latest funding rate and its total 24​hr trading volume.
 
 ## Installation
 

--- a/core.py
+++ b/core.py
@@ -198,13 +198,7 @@ def process_symbol(symbol: str, logger: logging.Logger) -> dict:
     if not klines:
         logger.warning("%s skipped: No valid klines returned.", symbol)
         return None
-    rate, ts = get_funding_rate(symbol)
-    if ts:
-        ts_str = datetime.fromtimestamp(ts / 1000, timezone.utc).strftime(
-            "%Y-%m-%d %H:%M:%S UTC"
-        )
-    else:
-        ts_str = ""
+    rate, _ = get_funding_rate(symbol)
     return {
         "Symbol": symbol,
         "5M": round(calculate_volume_change(klines, 5), 4),
@@ -213,5 +207,4 @@ def process_symbol(symbol: str, logger: logging.Logger) -> dict:
         "1H": round(calculate_volume_change(klines, 60), 4),
         "4H": round(calculate_volume_change(klines, 240), 4),
         "Funding Rate": rate,
-        "Funding Rate Timestamp": ts_str,
     }

--- a/scan.py
+++ b/scan.py
@@ -129,7 +129,7 @@ def export_to_excel(df: pd.DataFrame, symbol_order: list, logger: logging.Logger
             idx = df.columns.get_loc("Funding Rate")
             worksheet.set_column(idx, idx, None, funding_format)
 
-        for col in range(1, 6):
+        for col in range(1, 7):
             col_letter = chr(ord("A") + col)
             cell_range = f"{col_letter}3:{col_letter}1048576"
             worksheet.conditional_format(cell_range, {

--- a/test.py
+++ b/test.py
@@ -94,7 +94,7 @@ def test_process_symbol_with_mocked_logger():
         assert "1H" in result
         assert "4H" in result
         assert "Funding Rate" in result
-        assert "Funding Rate Timestamp" in result
+        assert "Funding Rate Timestamp" not in result
 
 def test_get_funding_rate_success_timestamp():
     """Ensure timestamp reflects when the rate was fetched."""


### PR DESCRIPTION
## Summary
- drop `Funding Rate Timestamp` from `process_symbol`
- update formatting rules so funding rate cells get coloured
- adjust test for timestamp removal
- tweak README wording about funding rates

## Testing
- `pip install -r requirements.txt`
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6841eedd35b08321af2e9d2da344f52b