### PR TITLE
Remove default recipient email

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,6 @@ EMAIL_TO    # Recipient email address
 EMAIL_FROM  # Sender address (defaults to SMTP_USER)
 ```
 
-If any of these variables are missing, email alerts will be skipped.
+If any variables are missing, the scan logs will list which ones were absent
+before skipping email alerts.
 

--- a/scan.py
+++ b/scan.py
@@ -68,8 +68,22 @@ def send_email_alert(subject: str, body: str, logger: logging.Logger) -> None:
     to_addr = os.getenv("EMAIL_TO")
     from_addr = os.getenv("EMAIL_FROM", user or "")
 
-    if not all([host, port, user, password, to_addr]):
-        logger.info("Email not configured. Skipping email alert.")
+    missing = [
+        name
+        for name, val in [
+            ("SMTP_HOST", host),
+            ("SMTP_PORT", port),
+            ("SMTP_USER", user),
+            ("SMTP_PASS", password),
+            ("EMAIL_TO", to_addr),
+        ]
+        if not val
+    ]
+    if missing:
+        logger.info(
+            "Email not configured. Missing %s. Skipping email alert.",
+            ", ".join(missing),
+        )
         return
 
     msg = EmailMessage()


### PR DESCRIPTION
## Summary
- require `EMAIL_TO` env variable again
- keep detailed log of any missing variables

## Testing
- `pip install -r requirements.txt`
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6841ed75efd88321aa641f7608151095