### PR TITLE
Fix pylint warnings in core and add utilities

### DIFF
--- a/scan_utils.py
+++ b/scan_utils.py
@@ -1,0 +1,18 @@
+"""Utility functions for the scanning workflow."""
+
+import time
+import logging
+
+
+def wait_for_file_close(path: str, logger: logging.Logger | None = None) -> None:
+    """Sleep until ``path`` can be opened for writing."""
+    if logger is None:
+        logger = logging.getLogger("volume_logger")
+    while True:
+        try:
+            with open(path, "a", encoding="utf-8"):
+                return
+        except OSError:
+            logger.debug("Waiting for %s to be released", path)
+            time.sleep(0.1)
+


### PR DESCRIPTION
## Summary
- document core module and all helper functions
- add a missing `SORTED_KLINES_CACHE` to share caching
- create a small `scan_utils` helper used by `scan.py`
- document scanner functions and clean up imports
- run lint and tests

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_684205f4a5f88321bd9b87f9a115c8f6