### PR TITLE
Improve open interest fetching

### DIFF
--- a/core.py
+++ b/core.py
@@ -203,23 +203,63 @@ def get_open_interest_change(symbol: str) -> float:
         "https://api.bybit.com/v5/market/open-interest"
         f"?category=linear&symbol={symbol}&interval=1h&limit=24"
     )
-    try:
-        response = requests.get(url, headers=get_auth_headers(), timeout=10)
-        response.raise_for_status()
-        data = response.json()
-        rows = data.get("result", {}).get("list", [])
-        if len(rows) < 2:
-            return 0.0
-        first = float(rows[0].get("openInterest", 0))
-        last = float(rows[-1].get("openInterest", 0))
-        if first == 0:
-            return 0.0
-        return ((last - first) / first) * 100
-    except (KeyError, ValueError, IndexError, requests.RequestException):
-        logging.getLogger("volume_logger").warning(
-            "Failed to fetch open interest for %s", symbol
-        )
-        return 0.0
+    logger = get_debug_logger()
+    for attempt in range(3):
+        try:
+            response = requests.get(url, headers=get_auth_headers(), timeout=10)
+            if response.status_code == 429:
+                delay = round(random.uniform(1.0, 2.5), 2)
+                logger.warning(
+                    "[%s] OI rate limit hit. Retrying in %.2fs...",
+                    symbol,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+            response.raise_for_status()
+            data = response.json()
+            if data.get("retCode") not in (0, None):
+                logger.warning(
+                    "[%s] OI API error %s: %s",
+                    symbol,
+                    data.get("retCode"),
+                    data.get("retMsg"),
+                )
+                time.sleep(1)
+                continue
+            rows = data.get("result", {}).get("list", [])
+            if len(rows) < 2:
+                return 0.0
+
+            rows.sort(key=lambda r: int(r.get("timestamp") or 0))
+
+            def extract_oi(row: dict) -> float:
+                for key in (
+                    "openInterest",
+                    "open_interest",
+                    "sumOpenInterest",
+                    "openInterestValue",
+                    "sumOpenInterestValue",
+                ):
+                    if key in row:
+                        try:
+                            return float(row.get(key, 0))
+                        except (TypeError, ValueError):
+                            return 0.0
+                return 0.0
+
+            first = extract_oi(rows[0])
+            last = extract_oi(rows[-1])
+            if first == 0:
+                return 0.0
+            return ((last - first) / first) * 100
+        except (KeyError, ValueError, IndexError, requests.RequestException) as err:
+            logger.warning(
+                "[%s] OI request attempt %d failed: %s", symbol, attempt + 1, err
+            )
+            time.sleep(1)
+    logger.error("[%s] Failed to fetch open interest after retries", symbol)
+    return 0.0
 
 
 def process_symbol(symbol: str, logger: logging.Logger) -> dict:


### PR DESCRIPTION
## Summary
- add retry logic and better error handling for fetching open interest
- test API error handling and rate limit retry logic

## Testing
- `python run_checks.py`


------
https://chatgpt.com/codex/tasks/task_e_6842aefaf97083219489ba0ad70880e9