### PR TITLE
Lazy load toast notifier

### DIFF
--- a/test.py
+++ b/test.py
@@ -246,11 +246,13 @@ def test_calculate_volume_change_cache_usage():
 
 
 def test_send_push_notification_sends_toast_on_windows():
-    """ToastNotifier called on Windows."""
+    """Toast notifier is used on Windows."""
     logger = MagicMock()
     with patch("scan.platform.system", return_value="Windows"), \
-         patch("scan.ToastNotifier") as mock_toast:
-        instance = mock_toast.return_value
+         patch("scan.get_toast_notifier") as mock_get:
+        notifier_cls = MagicMock()
+        mock_get.return_value = notifier_cls
+        instance = notifier_cls.return_value
         scan.send_push_notification("title", "msg", logger)
         instance.show_toast.assert_called_once_with("title", "msg", duration=5)
 
@@ -259,9 +261,9 @@ def test_send_push_notification_skips_on_non_windows():
     """No toast created when not running on Windows."""
     logger = MagicMock()
     with patch("scan.platform.system", return_value="Linux"), \
-         patch("scan.ToastNotifier") as mock_toast:
+         patch("scan.get_toast_notifier") as mock_get:
         scan.send_push_notification("title", "msg", logger)
-        mock_toast.assert_not_called()
+        mock_get.assert_not_called()
 
 
 def test_export_to_excel_swaps_column_order():


### PR DESCRIPTION
## Summary
- avoid importing `win10toast` at module import time
- update unit tests for new helper

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6842c84abcf08321ac664883f17f5553