### PR TITLE
Fix toast error by isolating notification

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -5,6 +5,8 @@ import logging
 import platform
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import importlib
+import subprocess
+import sys
 
 import pandas as pd
 from tqdm import tqdm
@@ -67,10 +69,21 @@ def send_push_notification(title: str, message: str, logger: logging.Logger) -> 
         return
 
     try:
-        notifier = notifier_class()
-        notifier.show_toast(title, message, duration=5)
+        subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "from win10toast import ToastNotifier;"
+                    f"ToastNotifier().show_toast({title!r}, {message!r}, duration=5)"
+                ),
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         logger.info("Windows notification sent")
-    except OSError as exc:  # pragma: no cover - platform specific error
+    except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover
         logger.warning("Failed to send notification: %s", exc)
 
 

--- a/test.py
+++ b/test.py
@@ -245,25 +245,25 @@ def test_calculate_volume_change_cache_usage():
 
 
 
-def test_send_push_notification_sends_toast_on_windows():
-    """Toast notifier is used on Windows."""
+def test_send_push_notification_runs_subprocess_on_windows():
+    """Notification launched via subprocess on Windows."""
     logger = MagicMock()
     with patch("scan.platform.system", return_value="Windows"), \
-         patch("scan.get_toast_notifier") as mock_get:
-        notifier_cls = MagicMock()
-        mock_get.return_value = notifier_cls
-        instance = notifier_cls.return_value
+         patch("scan.get_toast_notifier", return_value=object()), \
+         patch("scan.subprocess.run") as mock_run:
         scan.send_push_notification("title", "msg", logger)
-        instance.show_toast.assert_called_once_with("title", "msg", duration=5)
+        mock_run.assert_called_once()
 
 
 def test_send_push_notification_skips_on_non_windows():
-    """No toast created when not running on Windows."""
+    """No notification subprocess when not running on Windows."""
     logger = MagicMock()
     with patch("scan.platform.system", return_value="Linux"), \
-         patch("scan.get_toast_notifier") as mock_get:
+         patch("scan.get_toast_notifier") as mock_get, \
+         patch("scan.subprocess.run") as mock_run:
         scan.send_push_notification("title", "msg", logger)
         mock_get.assert_not_called()
+        mock_run.assert_not_called()
 
 
 def test_export_to_excel_swaps_column_order():


### PR DESCRIPTION
## Summary
- use subprocess to launch toast notification
- update tests for new subprocess approach

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6842ca2ce05c8321b1c1b75d0593a105