### PR TITLE
Implement price movement volatility scan

### DIFF
--- a/core.py
+++ b/core.py
@@ -12,6 +12,7 @@ import requests
 from tqdm import tqdm
 from volume_math import calculate_volume_change
 import correlation_math
+import volatility_math
 
 KLINE_CACHE = {}
 SORTED_KLINES_CACHE: dict[int, list] = {}
@@ -281,3 +282,19 @@ def process_symbol_funding(symbol: str, _logger: logging.Logger) -> dict:
     """Return the latest funding rate for ``symbol``."""
     rate, _ = get_funding_rate(symbol)
     return {"Symbol": symbol, "Funding Rate": rate}
+
+
+def process_symbol_volatility(symbol: str, logger: logging.Logger) -> dict:
+    """Return price range percentage movement metrics for ``symbol``."""
+    klines = fetch_recent_klines(symbol)
+    if not klines:
+        logger.warning("%s skipped: No valid klines returned for volatility.", symbol)
+        return None
+    return {
+        "Symbol": symbol,
+        "5M": round(volatility_math.calculate_price_range_percent(klines, 5), 4),
+        "15M": round(volatility_math.calculate_price_range_percent(klines, 15), 4),
+        "30M": round(volatility_math.calculate_price_range_percent(klines, 30), 4),
+        "1H": round(volatility_math.calculate_price_range_percent(klines, 60), 4),
+        "4H": round(volatility_math.calculate_price_range_percent(klines, 240), 4),
+    }

--- a/run_checks.py
+++ b/run_checks.py
@@ -17,6 +17,7 @@ PY_FILES = [
     "test.py",
     "volume_math.py",
     "correlation_math.py",
+    "volatility_math.py",
 ]
 
 

--- a/test.py
+++ b/test.py
@@ -12,6 +12,7 @@ import core
 import scan
 from volume_math import calculate_volume_change
 import correlation_math
+import volatility_math
 
 def test_get_tradeable_symbols_sorted_by_volume():
     """Test symbol sorting by 24h volume descending order."""
@@ -301,3 +302,39 @@ def test_export_to_excel_swaps_column_order():
         scan.export_to_excel(df, ["BTCUSDT"], logger)
         cols = captured.get("cols")
         assert cols.index("24h USD Volume") < cols.index("Funding Rate")
+
+def test_calculate_price_range_percent():
+    """Calculate correct high-low percentage for latest block."""
+    klines = [[str(i), "1", "10", "8", "", "1"] for i in range(5)]
+    result = volatility_math.calculate_price_range_percent(klines, 5)
+    assert round(result, 2) == 25.0
+
+
+def test_process_symbol_volatility_with_mocked_logger():
+    """Ensure volatility metrics include expected keys."""
+    mock_klines = [[str(i), "1", "10", "8", "", "1"] for i in range(5040)]
+    with patch("core.fetch_recent_klines", return_value=mock_klines):
+        result = core.process_symbol_volatility("BTCUSDT", MagicMock())
+        expected_keys = {"Symbol", "5M", "15M", "30M", "1H", "4H"}
+        assert set(result.keys()) == expected_keys
+
+
+def test_export_to_excel_skips_conditional_formatting():
+    """No conditional formatting applied when flag is False."""
+    df = pd.DataFrame([
+        {"Symbol": "BTCUSDT", "5M": 1.0}
+    ])
+    logger = MagicMock()
+    with patch("scan.pd.ExcelWriter") as mock_writer, \
+         patch("scan.wait_for_file_close"), \
+         patch("pandas.DataFrame.to_excel", autospec=True):
+        writer = MagicMock()
+        writer.book.add_format.return_value = MagicMock()
+        worksheet = MagicMock()
+        writer.sheets = {"Sheet1": worksheet}
+        mock_writer.return_value.__enter__.return_value = writer
+
+        scan.export_to_excel(df, ["BTCUSDT"], logger,
+                             filename="x.xlsx", header="hdr",
+                             apply_conditional_formatting=False)
+        worksheet.conditional_format.assert_not_called()

--- a/volatility_math.py
+++ b/volatility_math.py
@@ -1,0 +1,30 @@
+"""Compute percentage price range for a given block of klines."""
+
+from __future__ import annotations
+
+
+def calculate_price_range_percent(klines: list, block_size: int) -> float:
+    """Return the high-low percentage movement of the most recent block."""
+    import core  # pylint: disable=import-outside-toplevel
+
+    try:
+        k_id = id(klines)
+        if k_id in core.SORTED_KLINES_CACHE:
+            sorted_klines = core.SORTED_KLINES_CACHE[k_id]
+        else:
+            sorted_klines = sorted(klines, key=lambda k: int(k[0]))
+            core.SORTED_KLINES_CACHE[k_id] = sorted_klines
+
+        if len(sorted_klines) < block_size:
+            return 0.0
+
+        latest_block = sorted_klines[-block_size:]
+        highs = [float(k[2]) for k in latest_block]
+        lows = [float(k[3]) for k in latest_block]
+        high = max(highs)
+        low = min(lows)
+        if low == 0:
+            return 0.0
+        return (high - low) / low * 100
+    except (ValueError, IndexError, TypeError):
+        return 0.0


### PR DESCRIPTION
## Summary
- calculate high/low price range percent in new module `volatility_math.py`
- support conditional-formatting toggle for Excel exports
- add sequential volatility scan after correlation scan
- include new function in `run_checks.py`
- test volatility calculations and formatting skip logic

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6842d53460c08321abbbc0e2c0ec7188