### PR TITLE
Fix volatility_math IndentationError

### DIFF
--- a/volatility_math.py
+++ b/volatility_math.py
@@ -2,6 +2,16 @@
 
 from __future__ import annotations
 
+
+def calculate_price_range_percent(klines: list, block_size: int) -> float:
+    """Return the high-low percentage of the latest block of ``block_size`` klines."""
+    try:
+        sorted_klines = sorted(klines, key=lambda k: int(k[0]))
+        if len(sorted_klines) < block_size:
+            return 0.0
+        latest_block = sorted_klines[-block_size:]
+        highs = [float(k[2]) for k in latest_block]
+        lows = [float(k[3]) for k in latest_block]
         high = max(highs)
         low = min(lows)
         if low == 0:


### PR DESCRIPTION
## Summary
- repair `volatility_math.py` which had an indentation error and missing function definition
- add tests and lint run via `run_checks.py`

## Testing
- `pip install -r requirements.txt`
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6842e7e8bcd083219e17717ab034f629