### PR TITLE
Add 1D/1W/1M open interest metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Results are written to multiple spreadsheets:
 
 * ``Crypto_Volume.xlsx`` containing volume change statistics
 * ``Funding_Rates.xlsx`` with the latest funding rate for each pair
-* ``Open_Interest.xlsx`` showing percent changes in open interest across several timeframes
+* ``Open_Interest.xlsx`` showing percent changes in open interest across several timeframes, now including 1 day, 1 week and 1 month intervals
 
 The funding and open interest sheets omit the ``24h USD Volume`` column, but rows remain sorted using this metric.
 

--- a/core.py
+++ b/core.py
@@ -258,6 +258,9 @@ OPEN_INTEREST_INTERVALS = {
     "30M": "30min",
     "1H": "1h",
     "4H": "4h",
+    "1D": "1d",
+    "1W": "1w",
+    "1M": "1M",
 }
 
 

--- a/scan.py
+++ b/scan.py
@@ -118,8 +118,8 @@ def export_to_excel(
     df.to_excel(writer, index=False, sheet_name=sheet_name, startrow=1)
     worksheet = writer.sheets[sheet_name]
     header_format = writer.book.add_format({"bold": True})
-    span = "B1:I1" if "Open Interest Change" in df.columns else "B1:H1"
-    worksheet.merge_range(span, header, header_format)
+    end_col = chr(ord("A") + len(df.columns) - 1)
+    worksheet.merge_range(f"B1:{end_col}1", header, header_format)
     worksheet.freeze_panes(2, 0)
 
     red_format = writer.book.add_format({
@@ -139,7 +139,18 @@ def export_to_excel(
         worksheet.set_column(col_idx, col_idx, None, currency_format)
 
     percent_columns = [
-        name for name in ["5M", "15M", "30M", "1H", "4H", "Open Interest Change"]
+        name
+        for name in [
+            "5M",
+            "15M",
+            "30M",
+            "1H",
+            "4H",
+            "1D",
+            "1W",
+            "1M",
+            "Open Interest Change",
+        ]
         if name in df.columns
     ]
     for name in percent_columns:
@@ -152,15 +163,20 @@ def export_to_excel(
 
     if apply_conditional_formatting:
         columns_to_format = [
-            name for name in [
+            name
+            for name in [
                 "5M",
                 "15M",
                 "30M",
                 "1H",
                 "4H",
+                "1D",
+                "1W",
+                "1M",
                 "Open Interest Change",
                 "Funding Rate",
-            ] if name in df.columns
+            ]
+            if name in df.columns
         ]
         for name in columns_to_format:
             col = df.columns.get_loc(name)

--- a/test.py
+++ b/test.py
@@ -117,7 +117,7 @@ def test_process_symbol_open_interest_with_mocked_logger():
     """Ensure open interest metrics include all timeframes."""
     with patch("core.get_open_interest_change", return_value=5.0):
         result = core.process_symbol_open_interest("XRPUSDT", MagicMock())
-        expected_keys = {"Symbol", "5M", "15M", "30M", "1H", "4H"}
+        expected_keys = {"Symbol", "5M", "15M", "30M", "1H", "4H", "1D", "1W", "1M"}
         assert set(result.keys()) == expected_keys
 
 


### PR DESCRIPTION
## Summary
- extend open interest intervals with 1 day, 1 week and 1 month
- update Excel export formatting for the extra columns
- adjust test expectations
- document new timeframes in README

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f331b9ec8321b9bd71ab75a07f7a